### PR TITLE
Users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'fast_jsonapi'
 gem 'faraday'
 gem 'figaro'
 gem 'json'
+gem 'bcrypt'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,7 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    bcrypt (3.1.15)
     bootsnap (1.4.8)
       msgpack (~> 1.0)
     builder (3.2.4)
@@ -210,6 +211,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt
   bootsnap (>= 1.4.2)
   byebug
   capybara

--- a/app/controllers/api/v1/backgrounds_controller.rb
+++ b/app/controllers/api/v1/backgrounds_controller.rb
@@ -5,15 +5,7 @@ class Api::V1::BackgroundsController < ApplicationController
     weather = forecast.current.weather.downcase
     keywords = "#{weather}+#{city}"
     image = RESULTS.get_image(keywords)
-    render status: 200, body: image.to_json and return unless image.class == Image
+    render json: image, status: 200 and return unless image.class == Image
     render json: ImageSerializer.new(image), status: 200
-  end
-
-  private
-
-  RESULTS ||= ResultsFacade.new
-
-  def location_params
-    params.permit(:location)
   end
 end

--- a/app/controllers/api/v1/backgrounds_controller.rb
+++ b/app/controllers/api/v1/backgrounds_controller.rb
@@ -6,7 +6,7 @@ class Api::V1::BackgroundsController < ApplicationController
     keywords = "#{weather}+#{city}"
     image = RESULTS.get_image(keywords)
     render status: 200, body: image.to_json and return unless image.class == Image
-    render json: ImageSerializer.new(image)
+    render json: ImageSerializer.new(image), status: 200
   end
 
   private

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,2 @@
+class Api::V1::UsersController < ApplicationController
+end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,7 +1,14 @@
 class Api::V1::UsersController < ApplicationController
 
   def create
+    new_user = User.new(user_params)
+    new_user.api_key = SecureRandom.base64
     require "pry"; binding.pry
+    if new_user.save
+      render json: UserSerializer.new(new_user)
+    else
+      render json: new_user.errors.full_messages, status: 401
+    end
   end
 
   private

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,10 +1,11 @@
 class Api::V1::UsersController < ApplicationController
 
   def create
+    require "pry"; binding.pry
   end
 
   private
-  
+
   def user_params
     params.permit(:email, :password, :password_confirmation)
   end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -2,10 +2,9 @@ class Api::V1::UsersController < ApplicationController
 
   def create
     new_user = User.new(user_params)
-    new_user.api_key = SecureRandom.base64
-    require "pry"; binding.pry
+    new_user.api_key = SecureRandom.uuid
     if new_user.save
-      render json: UserSerializer.new(new_user)
+      render json: UserSerializer.new(new_user), status: 201
     else
       render json: new_user.errors.full_messages, status: 401
     end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,2 +1,11 @@
 class Api::V1::UsersController < ApplicationController
+
+  def create
+  end
+
+  private
+  
+  def user_params
+    params.permit(:email, :password, :password_confirmation)
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,8 @@
 class ApplicationController < ActionController::API
+  
+  RESULTS ||= ResultsFacade.new
+
+  def location_params
+    params.permit(:location)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,6 @@
+class User < ApplicationRecord
+  validates :email, uniqueness: true, presence: true
+  validates :password, presence: true
+
+  has_secure_password
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
   validates :email, uniqueness: true, presence: true
-  validates :password, presence: true
+  validates :password_digest, presence: true
 
   has_secure_password
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,4 @@
+class UserSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :email, :api_key
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,5 +33,8 @@ module SweaterWeather
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+
+    initializer(:remove_activestorage_routes, after: :add_routing_paths) {|app|
+      app.routes_reloader.paths.delete_if {|path| path =~ /activestorage/ || path =~ /actionmailbox/}}
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       get '/forecast', to: 'forecast#show'
       get '/backgrounds', to: 'backgrounds#show'
+      post '/users', to: 'users#create'
     end
   end
 end

--- a/db/migrate/20200922163527_create_users.rb
+++ b/db/migrate/20200922163527_create_users.rb
@@ -1,0 +1,9 @@
+class CreateUsers < ActiveRecord::Migration[6.0]
+  def change
+    create_table :users do |t|
+      t.string :email
+      t.string :password_digest
+      t.string :api_key
+    end
+  end
+end

--- a/db/migrate/20200922163527_create_users.rb
+++ b/db/migrate/20200922163527_create_users.rb
@@ -3,7 +3,6 @@ class CreateUsers < ActiveRecord::Migration[6.0]
     create_table :users do |t|
       t.string :email
       t.string :password_digest
-      t.string :api_key, default: nil
 
       t.timestamps
     end

--- a/db/migrate/20200922163527_create_users.rb
+++ b/db/migrate/20200922163527_create_users.rb
@@ -3,7 +3,9 @@ class CreateUsers < ActiveRecord::Migration[6.0]
     create_table :users do |t|
       t.string :email
       t.string :password_digest
-      t.string :api_key
+      t.string :api_key, default: nil
+
+      t.timestamps
     end
   end
 end

--- a/db/migrate/20200922164253_change_user_api_key_default.rb
+++ b/db/migrate/20200922164253_change_user_api_key_default.rb
@@ -1,0 +1,5 @@
+class ChangeUserApiKeyDefault < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :api_key, :string, default: nil 
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,26 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2020_09_22_164253) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "users", force: :cascade do |t|
+    t.string "email"
+    t.string "password_digest"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.string "api_key"
+  end
+
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,6 @@
+RSpec.describe User do
+  validates :email, uniqueness: true, presence: true
+  validates :password, require: true
+
+  has_secure_password
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe User do
   it { should validate_presence_of :email }
   it { should validate_uniqueness_of :email }
-  it { should validate_presence_of :password }
+  it { should validate_presence_of :password_digest }
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,5 @@
 RSpec.describe User do
-  validates :email, uniqueness: true, presence: true
-  validates :password, require: true
-
-  has_secure_password
+  it { should validate_presence_of :email }
+  it { should validate_uniqueness_of :email }
+  it { should validate_presence_of :password }
 end

--- a/spec/requests/api/v1/backgrounds/show_spec.rb
+++ b/spec/requests/api/v1/backgrounds/show_spec.rb
@@ -2,8 +2,10 @@ RSpec.describe 'Can fetch a background image for given location', type: :request
   it 'GET /api/v1/backgrounds?location=<city>,<state>' do
 
     location = 'denver,co'
+    headers = { "ACCEPT" => "application/json",
+                "Content-Type" => "application/json" }
 
-    get api_v1_backgrounds_path({location: location})
+    get api_v1_backgrounds_path({location: location}), headers: headers
 
     json = JSON.parse(response.body, symbolize_names: true)
 

--- a/spec/requests/api/v1/backgrounds/show_spec.rb
+++ b/spec/requests/api/v1/backgrounds/show_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Can fetch a background image for given location', type: :request
 
     json = JSON.parse(response.body, symbolize_names: true)
 
-    # expect(response.content_type).to include("application/json")
+    expect(response.content_type).to include("application/json")
     expect(response.status).to eq(200)
     expect(json).to eq([])
   end

--- a/spec/requests/api/v1/forecasts/show_spec.rb
+++ b/spec/requests/api/v1/forecasts/show_spec.rb
@@ -2,8 +2,10 @@ RSpec.describe 'Can get forecast for given city, state in json', type: :request 
   it 'GET /api/v1/forecast?location=<city>,<state>' do
 
     location = 'denver,co'
+    headers = { "ACCEPT" => "application/json",
+                "Content-Type" => "application/json" }
 
-    get api_v1_forecast_path({location: location})
+    get api_v1_forecast_path({location: location}), headers: headers
 
     json = JSON.parse(response.body, symbolize_names: true)
 

--- a/spec/requests/api/v1/forecasts/show_spec.rb
+++ b/spec/requests/api/v1/forecasts/show_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe 'Can get forecast for given city, state in json', type: :request 
       expect(day).to include(:max)
       expect(day).to include(:rain)
       expect(day).to include(:weather)
+      expect(day[:weather].class).to eq(String)
     end
 
     expect(json[:data][:attributes]).to_not include(:current_pressure)

--- a/spec/requests/api/v1/users/create_spec.rb
+++ b/spec/requests/api/v1/users/create_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe 'can create user from POST body and return unique api_key' do
-  it 'POST /api/v1/users' do
+  xit 'POST /api/v1/users' do
     body = {
               "email": "whatever@example.com",
-              "password": "password"
+              "password": "password",
               "password_confirmation": "password"
             }
 

--- a/spec/requests/api/v1/users/create_spec.rb
+++ b/spec/requests/api/v1/users/create_spec.rb
@@ -40,4 +40,25 @@ RSpec.describe 'can create user from POST body and return unique api_key' do
     expect(response.status).to eq(401)
     expect(json).to include("Password can't be blank")
   end
+
+  it 'Sad Path: duplicate email on POST /api/v1/users' do
+    user = User.create!(email: "whatever@example.com", password: "password")
+
+    body = {
+              email: "whatever@example.com",
+              password: "password",
+              password_confirmation: "password"
+            }.to_json
+
+    headers = { "ACCEPT" => "application/json",
+                "Content-Type" => "application/json" }
+
+    post api_v1_users_path, params: body, headers: headers
+
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response.content_type).to include("application/json")
+    expect(response.status).to eq(401)
+    expect(json).to include("Email has already been taken")
+  end
 end

--- a/spec/requests/api/v1/users/create_spec.rb
+++ b/spec/requests/api/v1/users/create_spec.rb
@@ -11,13 +11,12 @@ RSpec.describe 'can create user from POST body and return unique api_key' do
 
     post api_v1_users_path, params: body, headers: headers
 
-    # check request.POST to ensure data arrived as body.
     json = JSON.parse(response.body, symbolize_names: true)
 
     expect(response.content_type).to include("application/json")
     expect(response.status).to eq(201)
 
-    expect(json[:data][:type]).to eq('users')
+    expect(json[:data][:type]).to eq('user')
     expect(json[:data][:attributes]).to include(:email)
     expect(json[:data][:attributes][:email]).to eq("whatever@example.com")
 

--- a/spec/requests/api/v1/users/create_spec.rb
+++ b/spec/requests/api/v1/users/create_spec.rb
@@ -19,7 +19,25 @@ RSpec.describe 'can create user from POST body and return unique api_key' do
     expect(json[:data][:type]).to eq('user')
     expect(json[:data][:attributes]).to include(:email)
     expect(json[:data][:attributes][:email]).to eq("whatever@example.com")
-
+    expect(json[:data][:attributes]).to_not include(:password)
+    expect(json[:data][:attributes]).to_not include(:password_confirmation)
     expect(json[:data][:attributes]).to include(:api_key)
+  end
+
+  it 'Sad Path: missing field on POST /api/v1/users' do
+    body = {
+              email: "whatever@example.com"
+            }.to_json
+
+    headers = { "ACCEPT" => "application/json",
+                "Content-Type" => "application/json" }
+
+    post api_v1_users_path, params: body, headers: headers
+
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response.content_type).to include("application/json")
+    expect(response.status).to eq(401)
+    expect(json).to include("Password can't be blank")
   end
 end

--- a/spec/requests/api/v1/users/create_spec.rb
+++ b/spec/requests/api/v1/users/create_spec.rb
@@ -1,15 +1,15 @@
 RSpec.describe 'can create user from POST body and return unique api_key' do
-  xit 'POST /api/v1/users' do
+  it 'POST /api/v1/users' do
     body = {
-              "email": "whatever@example.com",
-              "password": "password",
-              "password_confirmation": "password"
-            }
+              email: "whatever@example.com",
+              password: "password",
+              password_confirmation: "password"
+            }.to_json
 
     headers = { "ACCEPT" => "application/json",
                 "Content-Type" => "application/json" }
 
-    post api_v1_users_path, body: body, headers: headers
+    post api_v1_users_path, body: body, format: :json
 
     json = JSON.parse(response.body, symbolize_names: true)
 

--- a/spec/requests/api/v1/users/create_spec.rb
+++ b/spec/requests/api/v1/users/create_spec.rb
@@ -1,0 +1,25 @@
+RSpec.describe 'can create user from POST body and return unique api_key' do
+  it 'POST /api/v1/users' do
+    body = {
+              "email": "whatever@example.com",
+              "password": "password"
+              "password_confirmation": "password"
+            }
+
+    headers = { "ACCEPT" => "application/json",
+                "Content-Type" => "application/json" }
+
+    post api_v1_users_path, body: body, headers: headers
+
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response.content_type).to include("application/json")
+    expect(response.status).to eq(201)
+
+    expect(json[:data][:type]).to eq('users')
+    expect(json[:data][:attributes]).to include(:email)
+    expect(json[:data][:attributes][:email]).to eq("whatever@example.com")
+
+    expect(json[:data][:attributes]).to include(:api_key)
+  end
+end

--- a/spec/requests/api/v1/users/create_spec.rb
+++ b/spec/requests/api/v1/users/create_spec.rb
@@ -9,8 +9,9 @@ RSpec.describe 'can create user from POST body and return unique api_key' do
     headers = { "ACCEPT" => "application/json",
                 "Content-Type" => "application/json" }
 
-    post api_v1_users_path, body: body, format: :json
+    post api_v1_users_path, params: body, headers: headers
 
+    # check request.POST to ensure data arrived as body.
     json = JSON.parse(response.body, symbolize_names: true)
 
     expect(response.content_type).to include("application/json")


### PR DESCRIPTION
- Create User model and spec
- Create Users table with email, password_digest, and api_key fields. Api_key has default of nil until a key is generated after creation. _maybe come back to this and use a callback of some sort?_
- Add `bcrypt` gem
- write and pass specs for user creation, including sad paths that return 401 and error messages
